### PR TITLE
Support both anotations and attributes for doctrine

### DIFF
--- a/src/Model/Calculator/DelegatingCalculator.php
+++ b/src/Model/Calculator/DelegatingCalculator.php
@@ -10,8 +10,9 @@ use ThreeBRS\SyliusPaymentFeePlugin\Model\PaymentMethodWithFeeInterface;
 
 final class DelegatingCalculator implements DelegatingCalculatorInterface
 {
-    public function __construct(private ServiceRegistryInterface $registry)
-    {
+    public function __construct(
+        private readonly ServiceRegistryInterface $registry,
+    ) {
     }
 
     public function calculate(PaymentInterface $subject): ?int

--- a/src/Model/PaymentChargesProcessor.php
+++ b/src/Model/PaymentChargesProcessor.php
@@ -13,8 +13,10 @@ use ThreeBRS\SyliusPaymentFeePlugin\Model\Calculator\DelegatingCalculatorInterfa
 
 final class PaymentChargesProcessor implements OrderProcessorInterface
 {
-    public function __construct(private FactoryInterface $adjustmentFactory, private DelegatingCalculatorInterface $paymentChargesCalculator)
-    {
+    public function __construct(
+        private readonly FactoryInterface $adjustmentFactory,
+        private readonly DelegatingCalculatorInterface $paymentChargesCalculator,
+    ) {
     }
 
     public function process(BaseOrderInterface $order): void
@@ -35,8 +37,12 @@ final class PaymentChargesProcessor implements OrderProcessorInterface
 
             $adjustment->setType(AdjustmentInterface::PAYMENT_ADJUSTMENT);
             $adjustment->setAmount($paymentCharge);
-            $adjustment->setLabel($payment->getMethod() !== null ? $payment->getMethod()->getName() : null);
-            $adjustment->setOriginCode($payment->getMethod() !== null ? $payment->getMethod()->getCode() : null);
+            $adjustment->setLabel($payment->getMethod() !== null
+                ? $payment->getMethod()->getName()
+                : null);
+            $adjustment->setOriginCode($payment->getMethod() !== null
+                ? $payment->getMethod()->getCode()
+                : null);
             $adjustment->setNeutral(false);
 
             $order->addAdjustment($adjustment);

--- a/src/Model/PaymentMethodWithFeeInterface.php
+++ b/src/Model/PaymentMethodWithFeeInterface.php
@@ -13,9 +13,9 @@ interface PaymentMethodWithFeeInterface extends PaymentMethodInterface, TaxableI
     public function getCalculator(): ?string;
 
     /**
-     * @return array<mixed>
+     * @return array<string, mixed>
      */
     public function getCalculatorConfiguration(): array;
 
-    public function setTaxCategory(?TaxCategoryInterface $category): void;
+    public function setTaxCategory(?TaxCategoryInterface $taxCategory): void;
 }

--- a/src/Model/PaymentMethodWithFeeTrait.php
+++ b/src/Model/PaymentMethodWithFeeTrait.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace ThreeBRS\SyliusPaymentFeePlugin\Model;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Taxation\Model\TaxCategoryInterface;
 
 trait PaymentMethodWithFeeTrait
 {
     /** @ORM\Column(name="calculator", type="text", nullable=true) */
+    #[ORM\Column(name: 'calculator', type: Types::TEXT, nullable: true)]
     protected ?string $calculator = null;
 
     /**
@@ -17,9 +19,12 @@ trait PaymentMethodWithFeeTrait
      *
      * @ORM\JoinColumn(name="tax_category_id")
      */
+    #[ORM\ManyToOne(targetEntity: TaxCategoryInterface::class)]
+    #[ORM\JoinColumn(name: 'tax_category_id')]
     protected ?TaxCategoryInterface $taxCategory = null;
 
     /** @ORM\Column(name="calculator_configuration", type="json", nullable=true) */
+    #[ORM\Column(name: 'calculator_configuration', type: 'json', nullable: true)]
     protected array $calculatorConfiguration = [];
 
     public function getCalculator(): ?string

--- a/src/Model/Taxation/Applicator/OrderPaymentTaxesApplicator.php
+++ b/src/Model/Taxation/Applicator/OrderPaymentTaxesApplicator.php
@@ -17,9 +17,9 @@ use ThreeBRS\SyliusPaymentFeePlugin\Model\PaymentMethodWithFeeInterface;
 class OrderPaymentTaxesApplicator implements OrderTaxesApplicatorInterface
 {
     public function __construct(
-        private CalculatorInterface $calculator,
-        private AdjustmentFactoryInterface $adjustmentFactory,
-        private TaxRateResolverInterface $taxRateResolver,
+        private readonly CalculatorInterface $calculator,
+        private readonly AdjustmentFactoryInterface $adjustmentFactory,
+        private readonly TaxRateResolverInterface $taxRateResolver,
     ) {
     }
 


### PR DESCRIPTION
Some projects uses PHP attributes only. For those previous annotations-only code does not work.

This change brings both ways of Doctrine mapping to support both, depending on project needs.