### PR TITLE
Allow null on $calculatorConfiguration

### DIFF
--- a/src/Model/PaymentMethodWithFeeTrait.php
+++ b/src/Model/PaymentMethodWithFeeTrait.php
@@ -20,7 +20,7 @@ trait PaymentMethodWithFeeTrait
     protected ?TaxCategoryInterface $taxCategory = null;
 
     /** @ORM\Column(name="calculator_configuration", type="json", nullable=true) */
-    protected array $calculatorConfiguration = [];
+    protected ?array $calculatorConfiguration = [];
 
     public function getCalculator(): ?string
     {
@@ -39,6 +39,10 @@ trait PaymentMethodWithFeeTrait
 
     public function setCalculatorConfiguration(array $calculatorConfiguration): void
     {
+        if ([] === $calculatorConfiguration) {
+            $calculatorConfiguration = null;
+        }
+
         $this->calculatorConfiguration = $calculatorConfiguration;
     }
 


### PR DESCRIPTION
I got an exception like this:

```
Cannot assign null to property App\Entity\PaymentMethod::$calculatorConfiguration of type array
```

This fixes that.