### PR TITLE
Do not recalculate price of non-cart order

### DIFF
--- a/src/Model/PaymentChargesProcessor.php
+++ b/src/Model/PaymentChargesProcessor.php
@@ -23,6 +23,10 @@ final class PaymentChargesProcessor implements OrderProcessorInterface
     {
         assert($order instanceof OrderInterface);
 
+        if (!$order->canBeProcessed()) {
+            return;
+        }
+
         $order->removeAdjustments(AdjustmentInterface::PAYMENT_ADJUSTMENT);
 
         foreach ($order->getPayments() as $payment) {


### PR DESCRIPTION
https://github.com/3BRS/sylius-payment-fee-plugin/issues/3

We have missed skip of order recalculation when the order is finished, similar to https://github.com/Sylius/Sylius/blob/2.0/src/Sylius/Component/Core/OrderProcessing/ShippingChargesProcessor.php#L39

https://3brs.youtrack.cloud/issue/SLS-92/Fix-payment-fee-plugin-order-recalculation